### PR TITLE
Fix condition for "Remove trailing whitespace on save" autocommand

### DIFF
--- a/packages/khanelivim/autocommands.nix
+++ b/packages/khanelivim/autocommands.nix
@@ -2,7 +2,7 @@
 {
   autoCmd = [
     # Remove trailing whitespace on save
-    (lib.mkIf (lib.elem "trim_whitespace" config.plugins.conform-nvim.settings.formatters_by_ft."_") {
+    (lib.mkIf (!lib.elem "trim_whitespace" config.plugins.conform-nvim.settings.formatters_by_ft."_") {
       event = "BufWrite";
       command = "%s/\\s\\+$//e";
     })


### PR DESCRIPTION
Actually does not create this auto command when conform trim_whitespace enabled
init.lua comparison:

![image](https://github.com/user-attachments/assets/b4a55295-d9c2-47c7-83f7-9a7cb63058dd)
